### PR TITLE
allowed origin에 와일드카드 사용을 위해 메서드 수정

### DIFF
--- a/src/main/java/com/hat/hereandthere/chatservice/config/WebSocketConfig.java
+++ b/src/main/java/com/hat/hereandthere/chatservice/config/WebSocketConfig.java
@@ -19,7 +19,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
 
     registry.addHandler(placeChatHandler(), "/place/*")
-        .setAllowedOrigins("*")
+        .setAllowedOriginPatterns("*")
         .withSockJS();
   }
 


### PR DESCRIPTION
개발의 편의를 위해 모든 origin을 허용하고자 `*`를 사용합니다.
Spring 5.3부터는 와일드카드를 사용하기 위해서
`setAllowedOrigins`가 아닌 `setAllowedOriginPatterns`를 사용해야 한다는 이슈가 있어 반영합니다.