### PR TITLE
DocumentDB cluster에 맞는 uri 설정

### DIFF
--- a/src/main/java/com/hat/hereandthere/chatservice/handler/PlaceChatHandler.java
+++ b/src/main/java/com/hat/hereandthere/chatservice/handler/PlaceChatHandler.java
@@ -62,6 +62,9 @@ public class PlaceChatHandler extends TextWebSocketHandler {
       log.error("Exception on parsing. {}", e.getMessage());
       session.close(CloseStatus.BAD_DATA);
     } catch (Exception e) {
+      for (StackTraceElement element : e.getStackTrace()) {
+        log.error(element.toString());
+      }
       log.error("Exception on publishing. {}", e.getMessage());
       session.close(CloseStatus.SERVER_ERROR);
     }

--- a/src/main/java/com/hat/hereandthere/chatservice/handler/PlaceChatHandler.java
+++ b/src/main/java/com/hat/hereandthere/chatservice/handler/PlaceChatHandler.java
@@ -62,9 +62,6 @@ public class PlaceChatHandler extends TextWebSocketHandler {
       log.error("Exception on parsing. {}", e.getMessage());
       session.close(CloseStatus.BAD_DATA);
     } catch (Exception e) {
-      for (StackTraceElement element : e.getStackTrace()) {
-        log.error(element.toString());
-      }
       log.error("Exception on publishing. {}", e.getMessage());
       session.close(CloseStatus.SERVER_ERROR);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
     mongodb:
-      uri: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}/${MONGODB_DATABASE}?authSource=admin
+      uri: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}/${MONGODB_DATABASE}?authSource=admin&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
       auto-index-creation: true
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
     mongodb:
-      uri: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}/${MONGODB_DATABASE}?authSource=admin&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
+      uri: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}/${MONGODB_DATABASE}?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
       auto-index-creation: true
 logging:
   level:


### PR DESCRIPTION
MongoDB에서 AWS DocumentDB로 변경됨에 따라 세부 설정이 변경되었습니다.

로컬 환경의 MongoDB와 다르게 AWS DocumentDB는 클러스터로 구성되어있기 때문에 write를 수행할 때, replica에도 동일하게 쓰기 작업을 수행할 수 있도록 해야합니다.

따라서 uri의 queryParam 부분이 변경되었습니다.


```
2024-07-13T16:33:55.586Z ERROR 6 --- [chat-service] [nio-8080-exec-5] c.h.h.c.handler.PlaceChatHandler         : Exception on publishing. Command failed with error 301: 'Retryable writes are not supported' on server dev-hat629-documentdb-cluster.cluster-c98g62sgokqz.ap-northeast-2.docdb.amazonaws.com:27017. The full response is {"ok": 0.0, "code": 301, "errmsg": "Retryable writes are not supported", "operationTime": {"$timestamp": {"t": 1720888435, "i": 1}}}
```
